### PR TITLE
Remove Quay and GitHub Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,58 +72,7 @@ oc apply -k argocd/non-prod/02-operator-instances/
 
 **Note:** In OpenShift 4.6, the `argocd-for-developers-instance` will remain "OutOfSync".  This is fixed in Argo CD 2.0 / OpenShift 4.7.  For now, this is fine.  Everything will be running properly.
 
-### 5. Generate Sealed Secrets for GitHub and Quay Credentials
-
-Part of this demo pushed new container images into your Quay.io account and creates/pushes branches in your git registry.  For this, your pipeline will need access to credentials.  In your cluster, information like this is managed by Kubernetes "Secrets".  However, it is a bad idea to put a standard "Secret" in a Git repository, since the data is only base64 encoded.  How do you manage Secrets in a GitOps world, then?  One option is to use Bitnami Sealed Secrets.
-
-In the previous step Sealed Secrets was installed into a new namespace called `sealed-secrets`.  Two helper pipelines have also been created in that namespace to make generated "sealed secrets" for your credentials easier.
-
-1. From the Developer Console, go to the "sealed-secrets" project and click on "Pipelines" in the left menu.
-2. Click on the "generate-git-repository-sealed-secret" Pipeline, then from the drop-down near the top-left of the screen select "Start".
-3. Fill in the fom with the following values:
-    * Keep the default value for SEALED_SECRETS_NAMESPACE
-    * SECRET_NAME: `github-creds-secret`
-    * SECRET_NAMESPACE: `contoso-cicd`
-    * GIT_HOST - keep default
-    * GIT_USERNAME: your github username
-    * GIT_EMAIL: your github account email address
-    * GIT_PASSWORD: If using GitHub, create an access token and use this instead of your password.
-4. Click "Start"
-
-If you watch the logs, you will see a multi-line JSON object printed at the end of the pipeline.  This is your encrypted git credentials secret!
-
-Create a new file in your gitops admin repo for this file:
-```
-dotnet-contoso-gitops-admins/overlays/01-namespaces/contoso-cicd/github-creds-secret-sealedsecret.json
-```
-Copy the JSON from the log output into this file.
-
-Similarly, we will create an encrypted Quay secret:
-1. From the Developer Console, go to the "sealed-secrets" project and click on "Pipelines" in the left menu.
-2. Click on the "generate-image-registry-sealed-secret" Pipeline, then from the drop-down near the top-left of the screen select "Start".
-3. Fill in the fom with the following values:
-    * Keep the default value for SEALED_SECRETS_NAMESPACE
-    * SECRET_NAME: `quay-creds-secret`
-    * SECRET_NAMESPACE: `contoso-cicd`
-    * REGISTRY_HOST - keep default
-    * REGISTRY_USERNAME: Your quay.io username
-    * REGISTRY_EMAIL: Your quay.io account email address
-    * REGISTRY_PASSWORD: Your quay.io password.
-4. Click "Start"
-
-If you watch the logs, you will see a multi-line JSON object printed at the end of the pipeline.  This is your encrypted quay.io credentials secret!
-
-Create a new file in your gitops admin repo for this file:
-```
-dotnet-contoso-gitops-admins/overlays/01-namespaces/contoso-cicd/quay-creds-secret-sealedsecret.json
-```
-Copy the JSON from the log output into this file.
-
-Finally, in the same directory where you created these new secrets, open the `kustomization.yaml` file and uncomment the two "resources" lines that reference these new files.
-
-Commmit/push the updates to your git repository, then "Sync" the `contoso-cicd-ns` Application in Argo CD to have the changes reflected immediately.
-
-### 6. Configure Developer Namesapces
+### 5. Configure Developer Namesapces
 
 Now that the "Admins" have setup the cluster and created the namespaces for developers to use, it's time for the developers to do some things!
 
@@ -139,7 +88,7 @@ This will do all the work!  Login to the "Developer" version of Argo CD, and you
 * contoso-dev
 * contoso-test
 
-### 7. Configure Nexus as a NuGet Proxy
+### 6. Configure Nexus as a NuGet Proxy
 
 One manual task (for now) is configuring Nexus to proxy NuGet.  To do this:
 
@@ -156,7 +105,7 @@ One manual task (for now) is configuring Nexus to proxy NuGet.  To do this:
     * Checksum Policy: `Ignore`
 7. Click **Save**
 
-### 8. Trigger your first Pipeline Run
+### 7. Trigger your first Pipeline Run
 
 Your pipeline is ready and the build tools are configured.  Time to run a build!
 

--- a/overlays/non-prod/01-namespaces/contoso-cicd/kustomization.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/kustomization.yaml
@@ -8,5 +8,5 @@ bases:
 
 resources:
   - namespace.yaml
-  - quay-creds-secret-sealedsecret.json
-  - github-creds-secret-sealedsecret.json
+#  - quay-creds-secret-sealedsecret.json
+#  - github-creds-secret-sealedsecret.json


### PR DESCRIPTION
Now using internal OpenShift registry and not attempting to create branch and PR in GitHub, so no need to include credentials as sealed secrets/